### PR TITLE
Remove "Set the accent color" section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ The most epic theme meets Visual Studio Code. You can help by reporting issues [
   - [Installation](#installation)
       - [GitHub Repository Clone](#github-repository-clone)
 - [Activate theme](#activate-theme)
-- [Set the accent color](#set-the-accent-color)
 - [Override theme colors](#override-theme-colors)
   - [Color Scheme override](#color-scheme-override)
 - [Recommended settings for a better experience](#recommended-settings-for-a-better-experience)
@@ -67,17 +66,6 @@ Launch *Quick Open*:
   - <img src="https://www.microsoft.com/favicon.ico" width=16 height=16/> <a href="https://code.visualstudio.com/shortcuts/keyboard-shortcuts-windows.pdf">Windows</a> `Ctrl + Shift + P`
 
 Type `theme`, choose `Preferences: Color Theme`, and select one of the Material Theme variants from the list. After activation, the theme will set the correct icon theme based on your active theme variant.
-
-## Set the accent color
-
-Launch *Quick Open*:
-
-  - <img src="https://www.kernel.org/theme/images/logos/favicon.png" width=16 height=16/> <a href="https://code.visualstudio.com/shortcuts/keyboard-shortcuts-linux.pdf">Linux</a> `Ctrl + Shift + P`
-  - <img src="https://developer.apple.com/favicon.ico" width=16 height=16/> <a href="https://code.visualstudio.com/shortcuts/keyboard-shortcuts-macos.pdf">macOS</a> `⌘ + Shift + P`
-  - <img src="https://www.microsoft.com/favicon.ico" width=16 height=16/> <a href="https://code.visualstudio.com/shortcuts/keyboard-shortcuts-windows.pdf">Windows</a> `Ctrl + Shift + P`
-
-Type `material theme`, choose `Material Theme: Set accent color`, and pick one color from the list.
-
 
 ## Override theme colors
 You can override the Material Theme UI and schemes colors by adding these theme-specific settings to your configuration. For advanced customisation please check the [relative section on the VS Code documentation](https://code.visualstudio.com/docs/getstarted/themes#_customizing-a-color-theme).


### PR DESCRIPTION
Remove "Set the accent color" section from README.md file since the command no longer exist.